### PR TITLE
Ajout des centres aux comptes utilisateurs

### DIFF
--- a/app/controllers/api/v2/accounts_controller.rb
+++ b/app/controllers/api/v2/accounts_controller.rb
@@ -227,6 +227,8 @@ class Api::V2::AccountsController < Api::V2::BaseController
         :gadz_fams_zaloeil,
         :gadz_proms_principale,
         :gadz_proms_secondaire,
+        :gadz_centre_principal,
+        :gadz_centre_secondaire,
         :avatar_url,
         :description
       )

--- a/app/controllers/api/v2/accounts_controller.rb
+++ b/app/controllers/api/v2/accounts_controller.rb
@@ -198,7 +198,38 @@ class Api::V2::AccountsController < Api::V2::BaseController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def api_v2_account_params
-      params.require(:account).permit(:uuid, :hruid, :id_soce, :enabled, :password, :lastname, :firstname, :birthname, :birth_firstname, :email, :gapps_id, :password, :birthdate, :deathdate, :gender, :is_gadz, :is_student, :school_id, :is_alumni, :date_entree_ecole, :date_sortie_ecole, :ecole_entree, :buque_texte, :buque_zaloeil, :gadz_fams, :gadz_fams_zaloeil, :gadz_proms_principale, :gadz_proms_secondaire, :avatar_url, :description)
+      params.require(:account).permit(
+        :uuid,
+        :hruid,
+        :id_soce,
+        :enabled,
+        :password,
+        :lastname,
+        :firstname,
+        :birthname,
+        :birth_firstname,
+        :email,
+        :gapps_id,
+        :password,
+        :birthdate,
+        :deathdate,
+        :gender,
+        :is_gadz,
+        :is_student,
+        :school_id,
+        :is_alumni,
+        :date_entree_ecole,
+        :date_sortie_ecole,
+        :ecole_entree,
+        :buque_texte,
+        :buque_zaloeil,
+        :gadz_fams,
+        :gadz_fams_zaloeil,
+        :gadz_proms_principale,
+        :gadz_proms_secondaire,
+        :avatar_url,
+        :description
+      )
     end
 
     def  show_password_hash?

--- a/app/serializers/master_data/account_serializer.rb
+++ b/app/serializers/master_data/account_serializer.rb
@@ -4,6 +4,7 @@ class MasterData::AccountSerializer < BaseSerializer
   has_many :roles, serializer: MasterData::RoleSerializer
 
   attributes :uuid, :hruid, :id_soce, :enabled, :lastname, :firstname, :birthname, :birth_firstname, :email, :gapps_id, :birthdate, :deathdate, :gender, :is_gadz, :is_student, :school_id, :is_alumni, :date_entree_ecole, :date_sortie_ecole, :ecole_entree, :buque_texte, :buque_zaloeil, :gadz_fams, :gadz_fams_zaloeil, :gadz_proms_principale, :gadz_proms_secondaire, :avatar_url, :description, :audit_status, :audit_comments, :is_from_legacy_gram1
+  attributes :gadz_centre_principal, :gadz_centre_secondaire
   attributes :url
 
     attribute :password, if: -> {instance_options[:show_password_hash]}

--- a/app/views/api/v2/accounts/show.html.haml
+++ b/app/views/api/v2/accounts/show.html.haml
@@ -82,6 +82,12 @@
   %strong Gadz proms secondaire:
   = @account.gadz_proms_secondaire
 %p
+  %strong Gadz centre principal:
+  = @account.gadz_centre_principal || ''
+%p
+  %strong Gadz centre secondaire:
+  = @account.gadz_centre_secondaire || ''
+%p
   %strong Avatar url:
   = @account.avatar_url
 %p

--- a/db/migrate/20180216153322_add_gadz_centre_to_master_data_account.rb
+++ b/db/migrate/20180216153322_add_gadz_centre_to_master_data_account.rb
@@ -1,0 +1,6 @@
+class AddGadzCentreToMasterDataAccount < ActiveRecord::Migration
+  def change
+    add_column :gram_accounts, :gadz_centre_principal, :string
+    add_column :gram_accounts, :gadz_centre_secondaire, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,9 @@ ActiveRecord::Schema.define(version: 20161115135718) do
     t.string   "audit_comments"
     t.string   "updated_by",            default: ""
     t.string   "password_updated_by",   default: ""
-    t.datetime "password_updated_at"
+    t.datetime "password_updated_at",
+    t.string   "gadz_centre_principal",
+    t.string   "gadz_centre_secondaire"
   end
 
   add_index "gram_accounts", ["audit_status"], name: "index_gram_accounts_on_audit_status", using: :btree

--- a/spec/serializers/master_data/account_serializer_spec.rb
+++ b/spec/serializers/master_data/account_serializer_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe MasterData::AccountSerializer, :type => :serializer do
+  before(:each) do
+    @account = FactoryGirl.build(:master_data_account)
+    serializer = MasterData::AccountSerializer.new(@account)
+    @serialization = ActiveModelSerializers::Adapter.create(serializer)
+  end
+
+  subject { JSON.parse(@serialization.to_json) }
+
+  describe "attributes" do
+    it "should include proms and centre" do
+      @account.attributes = {
+        gadz_proms_principale: "2017",
+        gadz_centre_principal: "ch"
+      }
+      
+      expect(subject["gadz_proms_principale"]).to eq("2017")
+      expect(subject["gadz_centre_principal"]).to eq("ch")
+    end
+  end
+end


### PR DESCRIPTION
Suite à la demande de mise à jour du site Soce afin d'exposer le centre principal des élèves à l'applicatif GrAM2, ce correctif assure la bonne réception des paramètres `gadz_centre_principal` et `gadz_centre_secondaire` lors d'un appel sur le endpoint `POST /api/v2/accounts`.

Résumé du correctif :

- [x] Migration de la table `gram_accounts` pour ajouter les champs `gadz_centre_principal` et
`gadz_centre_secondaire`
- [x] Mise à jour des « strong parameters » filtrés par `Api::V2::AccountsController` pour laisser passer `gadz_centre_principal` et `gadz_centre_secondaire` lors du `POST /api/v2/
accounts`
- [x] Mise à jour des attributs sérialisés des comptes dans le `MasterData::AccountSerializer` pour exposer `gadz_centre_principal` et `gadz_centre_secondaire` lors d’un `GET /api/v2/account/:hruid`

A noter, une synchro de `Site Soce` vers `GrAM2` sera nécessaire pour alimenter les comptes créés antérieurement à cette mise à jour.

A noter également, je n'ai pas trouvé de versionnement de l'application, merci de me le préciser le cas échéant.
